### PR TITLE
feat: implement automated coverage threshold management

### DIFF
--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -35,6 +35,33 @@ jobs:
         working-directory: client
         run: npm run test:ci
 
+      - name: Update coverage thresholds if improved
+        if: github.event_name == 'pull_request'
+        working-directory: client
+        run: |
+          npm run coverage:update || true
+          
+      - name: Check if thresholds were updated
+        if: github.event_name == 'pull_request'
+        id: check-thresholds
+        run: |
+          if git diff --quiet client/coverage.thresholds.json; then
+            echo "updated=false" >> $GITHUB_OUTPUT
+          else
+            echo "updated=true" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Commit updated thresholds
+        if: github.event_name == 'pull_request' && steps.check-thresholds.outputs.updated == 'true'
+        run: |
+          git config --local user.email "coverage-bot@github.com"
+          git config --local user.name "coverage-bot"
+          git add client/coverage.thresholds.json
+          git commit -m "chore: update coverage thresholds
+
+          🤖 Generated with [GitHub Actions](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})"
+          git push
+
       - name: Comment coverage on PR
         if: github.event_name == 'pull_request'
         uses: davelosert/vitest-coverage-report-action@v2

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -14,6 +14,9 @@ on:
 jobs:
   coverage:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     
     steps:
       - uses: actions/checkout@v4

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,0 @@
-cd client && npm run precommit

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,35 @@
+# Get the branch being pushed to
+remote="$1"
+url="$2"
+
+# Read from stdin to get refs being pushed
+while read local_ref local_sha remote_ref remote_sha; do
+  # Extract branch name from remote_ref (refs/heads/branch-name)
+  branch=$(echo "$remote_ref" | sed 's|refs/heads/||')
+  
+  # Only run checks when pushing to main branch
+  if [ "$branch" = "main" ]; then
+    echo "🔍 Running pre-push checks for main branch..."
+    cd client && npm run precommit
+    
+    # Check if the command failed
+    if [ $? -ne 0 ]; then
+      echo ""
+      echo "❌ Pre-push checks failed!"
+      echo ""
+      echo "💡 To fix this:"
+      echo "  1. Review the test failures or coverage issues above"
+      echo "  2. Fix any failing tests"
+      echo "  3. If coverage dropped, either:"
+      echo "     - Write more tests to improve coverage, or"
+      echo "     - Run 'npm run coverage:update' to accept current levels"
+      echo "  4. Commit any fixes and try pushing again"
+      echo ""
+      exit 1
+    fi
+    
+    echo "✅ Pre-push checks passed!"
+  else
+    echo "⏭️  Skipping pre-push checks for branch: $branch"
+  fi
+done


### PR DESCRIPTION
  - Add Husky pre-push hook that enforces coverage only on main branch
  - Create coverage threshold update script for manual/automated use
  - Configure GitHub Actions coverage-bot to auto-update thresholds on PRs
  - Fix Vite config to conditionally load thresholds (prevents Docker build issues)
  - Enable coverage ratcheting: thresholds automatically increase when coverage improves